### PR TITLE
updated links to live code demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ sanskrit
 ========
 #For using the code online:
 
-Use http://lanover.com/lan/sanskrit/sandhi.html for sandhi generation.
+Use http://www.sanskritworld.in/sanskrittool/sandhi.html for sandhi generation.
 
-Use http://lanover.com/lan/sanskrit/subanta.html for subanta generation.
+Use http://www.sanskritworld.in/sanskrittool/subanta.html for subanta generation.
 
 #For using the code offline on your computer:
 


### PR DESCRIPTION
Updated links to live code demos. The old links now give a "Page Not Found" error and are confusing. I thought this would be fine considering https://github.com/drdhaval2785/SanskritVerb also links to http://www.sanskritworld.in.